### PR TITLE
Switch PNG converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build an SVG sprite with PNG fallback from a folder of single SVGs.
 
 [![build status](https://secure.travis-ci.org/pliersjs/pliers-svg-sprite.png)](http://travis-ci.org/pliersjs/pliers-svg-sprite)
 
-Uses [SVG Sprite](https://www.npmjs.org/package/svg-sprite) and [SVG to PNG](https://www.npmjs.org/package/svg-to-png) under the hood.
+Uses [svg-sprite](https://www.npmjs.org/package/svg-sprite) and [svg2png](https://www.npmjs.org/package/svg2png) under the hood.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",
     "svg-sprite": "^1.2.10",
-    "svg-to-png": "^2.0.1"
+    "svg2png": ">=2.1.0 <3.0.0"
   },
   "devDependencies": {
     "async": "^1.4.2",

--- a/pliers-svg-sprite.js
+++ b/pliers-svg-sprite.js
@@ -3,7 +3,7 @@ var SVGSpriter = require('svg-sprite')
   , path = require('path')
   , fs = require('fs')
   , mkdirp = require('mkdirp')
-  , svgToPng = require('svg-to-png')
+  , svg2png = require('svg2png')
 
 module.exports = function (pliers, config) {
 
@@ -74,9 +74,8 @@ module.exports = function (pliers, config) {
       }
 
       // Convert generated SVG sprite to PNG and output in same directory
-      svgToPng.convert(outputSvgFile, imgOutputDir).then(function () {
-        done()
-      })
+      svg2png(outputSvgFile, outputSvgFile.replace('.svg', '.png'), done)
+
     }
 
   }

--- a/test/pliers-svg-sprite.test.js
+++ b/test/pliers-svg-sprite.test.js
@@ -141,4 +141,25 @@ describe('pliers-svg-sprite', function () {
     })
   })
 
+  it('should error if svg2png returns an error', function (done) {
+    var pliers = createPliers()
+      , config =
+        { imgSourceDir: fixturesDir + '/images'
+        , imgOutputDir: tempDir + '/images'
+        , stylusTemplate: fixturesDir + '/stylus/sprite.styl.tpl'
+        , stylusDest: tempDir + '/sprite.styl'
+        }
+      , destroy = pliersSvgSprite.__set__('svg2png', function (a, b, cb) {
+          cb(new Error('svg2png returned an error'))
+        })
+
+    pliers('buildSprite', pliersSvgSprite(pliers, config))
+
+    pliers.run('buildSprite', function (error) {
+      assert.equal(error.message, 'svg2png returned an error')
+      destroy()
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
Updates PNG converter to `svg2png`, to get rid of an `imagemin` dependency in `svg-to-png`.

Crude banchmark (with clear npm cache):

**Old version (`svg-to-png`)**
4527 dependencies
`npm i  132.32s user 32.34s system 116% cpu 2:21.00 total` (I'd seen 3mins+ in some cases)

**New version (`svg2png`)**
229 dependencies
`npm i  14.85s user 4.04s system 109% cpu 17.309 total`

Quite the improvement :smile:

New package still uses phantom, so it's not the quickest thing ever to install, but the initial PNG test results look the same. I'm manually testing some existing projects using this module to confirm PNG output is consistent across a wider range before merging/releasing.
